### PR TITLE
feat: Add vercel.json to fix SPA routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a `vercel.json` configuration file with a rewrite rule to redirect all requests to `index.html`.

This is necessary to fix a common issue with Single-Page Applications (SPAs) on Vercel where direct navigation to routes other than the root (e.g., /admin, /auth) results in a 404 Not Found error. This change ensures that the client-side router can handle all navigation correctly.