### PR TITLE
fix: Display banner image on event cards

### DIFF
--- a/src/components/EventsSection.tsx
+++ b/src/components/EventsSection.tsx
@@ -136,6 +136,13 @@ const EventsSection = () => {
           y: -10,
           scale: 1.02
         }} className="glass-card p-6 group cursor-pointer">
+              {event.banner_image_url && (
+                <img
+                  src={event.banner_image_url}
+                  alt={event.title}
+                  className="w-full h-48 object-cover rounded-md mb-4"
+                />
+              )}
               {/* Status Badge */}
               <div className="flex justify-between items-start mb-4">
                 <span className="px-3 py-1 rounded-full text-xs font-bebas border border-primary text-primary">


### PR DESCRIPTION
The `EventsSection.tsx` component was fetching the `banner_image_url` for each event but was not rendering it.

This change adds an `<img>` tag to the event card component, inside `EventsSection.tsx`, to display the banner image. It includes a conditional check to ensure the image only renders if a URL is present. Appropriate styling has been added to ensure the image fits the card design.